### PR TITLE
Recommend usage of state flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,7 @@
 [Passport](http://passportjs.org/) strategy for authenticating with [Heroku](https://heroku.com/)
 using the OAuth 2.0 API.
 
-This module lets you authenticate using Heroku in your Node.js applications.
-By plugging into Passport, Heroku authentication can be easily and
-unobtrusively integrated into any application or framework that supports
-[Connect](http://www.senchalabs.org/connect/)-style middleware, including
-[Express](http://expressjs.com/).
+This module lets you authenticate using Heroku in your Node.js applications. By plugging into Passport, Heroku authentication can be easily and unobtrusively integrated into any application or framework that supports [Connect](http://www.senchalabs.org/connect/)-style middleware, including [Express](http://expressjs.com/).
 
 ## Install
 
@@ -19,10 +15,7 @@ $ npm install passport-heroku
 
 #### Configure Strategy
 
-The Heroku authentication strategy authenticates users using a Heroku account
-and OAuth 2.0 tokens.  The strategy requires a `verify` callback, which accepts
-these credentials and calls `done` providing a user, as well as `options`
-specifying a client ID, client secret, and callback URL.
+The Heroku authentication strategy authenticates users using a Heroku account and OAuth 2.0 tokens.  The strategy requires a `verify` callback, which accepts these credentials and calls `done` providing a user, as well as `options` specifying a client ID, client secret, and callback URL.
 
 ```js
 passport.use(new HerokuStrategy({
@@ -40,17 +33,15 @@ passport.use(new HerokuStrategy({
 
 #### Authenticate Requests
 
-Use `passport.authenticate()`, specifying the `'heroku'` strategy, to
-authenticate requests.
+Use `passport.authenticate()`, specifying the `'heroku'` strategy, to authenticate requests.
 
-For example, as route middleware in an [Express](http://expressjs.com/)
-application:
+For example, as route middleware in an [Express](http://expressjs.com/) application:
 
 ```js
 app.get('/auth/heroku',
   passport.authenticate('heroku'));
 
-app.get('/auth/heroku/callback', 
+app.get('/auth/heroku/callback',
   passport.authenticate('heroku', { failureRedirect: '/login' }),
   function(req, res) {
     // Successful authentication, redirect home.
@@ -81,4 +72,3 @@ $ make test
 [The MIT License](http://opensource.org/licenses/MIT)
 
 Copyright (c) 2013 Mick Thompson <[http://mick.im/](http://mick.im/)>
-

--- a/README.md
+++ b/README.md
@@ -17,11 +17,14 @@ $ npm install passport-heroku
 
 The Heroku authentication strategy authenticates users using a Heroku account and OAuth 2.0 tokens.  The strategy requires a `verify` callback, which accepts these credentials and calls `done` providing a user, as well as `options` specifying a client ID, client secret, and callback URL.
 
+The `state` flag turns on a valuable protection against login CSRF attacks, but is reliant on sessions being enabled. If you're using sessions, you should set the flag and get a layer of defense for free. If you set the flag and no session exists, an error will be thrown.
+
 ```js
 passport.use(new HerokuStrategy({
     clientID: Heroku_CLIENT_ID,
     clientSecret: Heroku_CLIENT_SECRET,
-    callbackURL: "http://127.0.0.1:3000/auth/heroku/callback"
+    callbackURL: "http://127.0.0.1:3000/auth/heroku/callback",
+    state: true // CSRF protection, necessitates sessions
   },
   function(accessToken, refreshToken, profile, done) {
     User.findOrCreate({ githubId: profile.id }, function (err, user) {

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ passport.use(new HerokuStrategy({
     state: true // CSRF protection, necessitates sessions
   },
   function(accessToken, refreshToken, profile, done) {
-    User.findOrCreate({ githubId: profile.id }, function (err, user) {
+    User.findOrCreate({ herokuId: profile.id }, function (err, user) {
       return done(err, user);
     });
   }


### PR DESCRIPTION
The state flag is supported by [passport-oauth2](https://github.com/jaredhanson/passport-oauth2/blob/1eb4f22d5f6ca8bc6b08856f91779f67e5082fe0/lib/state/session.js#L7), and turns on automatic protection against login CSRF attacks if sessions are being used.

This pull updates the docs to recommend the usage of the flag.

I've also unwrapped paragraphs in the readme, see the diffs for 4fcb573 and a7306d2 for the actual content changes without the noise from the unwrapping.